### PR TITLE
Add support for Halium init

### DIFF
--- a/webos_deploy.sh
+++ b/webos_deploy.sh
@@ -55,6 +55,12 @@ deploy_luneos() {
     mv $tmp_extract $target_dir
     rm -rf $tmp_extract
 
+    # Recreate symlink for Halium
+    rm /data/halium-rootfs
+    if [ ! -e /data/halium-rootfs ]; then
+        ln -sf luneos /data/halium-rootfs
+    fi
+
     echo "Done with deploying LuneOS!!!"
 }
 


### PR DESCRIPTION
Halium's init looks for /data/halium-rootfs to find a rootfs deployed in a directory.
So add a symlink from to our /data/luneos.